### PR TITLE
Fix S(v interface{}) function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.8
-  - 1.9
+  - 1.13
+  - 1.14
 
 before_script:
   - go get github.com/kevinpfab/ptr

--- a/deref_test.go
+++ b/deref_test.go
@@ -10,7 +10,7 @@ func TestDBoolValue(t *testing.T) {
 	def := false
 	res := DBool(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -18,7 +18,7 @@ func TestDBoolDefault(t *testing.T) {
 	def := true
 	res := DBool(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -27,7 +27,7 @@ func TestDByteValue(t *testing.T) {
 	def := byte(20)
 	res := DByte(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -35,7 +35,7 @@ func TestDByteDefault(t *testing.T) {
 	def := byte(20)
 	res := DByte(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -44,7 +44,7 @@ func TestDComplex64Value(t *testing.T) {
 	def := complex64(20)
 	res := DComplex64(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -52,7 +52,7 @@ func TestDComplex64Default(t *testing.T) {
 	def := complex64(20)
 	res := DComplex64(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -61,7 +61,7 @@ func TestDComplex128Value(t *testing.T) {
 	def := complex128(20)
 	res := DComplex128(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -69,7 +69,7 @@ func TestDComplex128Default(t *testing.T) {
 	def := complex128(20)
 	res := DComplex128(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -78,7 +78,7 @@ func TestDDurationValue(t *testing.T) {
 	def := time.Duration(10)
 	res := DDuration(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -86,7 +86,7 @@ func TestDDurationDefault(t *testing.T) {
 	def := time.Duration(10)
 	res := DDuration(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestDFloat32Value(t *testing.T) {
 	def := float32(20)
 	res := DFloat32(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestDFloat32Default(t *testing.T) {
 	def := float32(20)
 	res := DFloat32(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -112,7 +112,7 @@ func TestDFloat64Value(t *testing.T) {
 	def := float64(20)
 	res := DFloat64(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -120,7 +120,7 @@ func TestDFloat64Default(t *testing.T) {
 	def := float64(20)
 	res := DFloat64(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -129,7 +129,7 @@ func TestDIntValue(t *testing.T) {
 	def := int(20)
 	res := DInt(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -137,7 +137,7 @@ func TestDIntDefault(t *testing.T) {
 	def := int(20)
 	res := DInt(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -146,7 +146,7 @@ func TestDInt8Value(t *testing.T) {
 	def := int8(20)
 	res := DInt8(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -154,7 +154,7 @@ func TestDInt8Default(t *testing.T) {
 	def := int8(20)
 	res := DInt8(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -163,7 +163,7 @@ func TestDInt16Value(t *testing.T) {
 	def := int16(20)
 	res := DInt16(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -171,7 +171,7 @@ func TestDInt16Default(t *testing.T) {
 	def := int16(20)
 	res := DInt16(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -180,7 +180,7 @@ func TestDInt32Value(t *testing.T) {
 	def := int32(20)
 	res := DInt32(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -188,7 +188,7 @@ func TestDInt32Default(t *testing.T) {
 	def := int32(20)
 	res := DInt32(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -197,7 +197,7 @@ func TestDInt64Value(t *testing.T) {
 	def := int64(20)
 	res := DInt64(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -205,7 +205,7 @@ func TestDInt64Default(t *testing.T) {
 	def := int64(20)
 	res := DInt64(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -214,7 +214,7 @@ func TestDRuneValue(t *testing.T) {
 	def := rune(20)
 	res := DRune(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -222,7 +222,7 @@ func TestDRuneDefault(t *testing.T) {
 	def := rune(20)
 	res := DRune(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -231,7 +231,7 @@ func TestDStringValue(t *testing.T) {
 	def := "two"
 	res := DString(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -239,7 +239,7 @@ func TestDStringDefault(t *testing.T) {
 	def := "two"
 	res := DString(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -248,7 +248,7 @@ func TestDTimeValue(t *testing.T) {
 	def := time.Now().Add(10 * time.Minute)
 	res := DTime(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -256,7 +256,7 @@ func TestDTimeDefault(t *testing.T) {
 	def := time.Now().Add(10 * time.Minute)
 	res := DTime(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -265,7 +265,7 @@ func TestDUintValue(t *testing.T) {
 	def := uint(20)
 	res := DUint(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -273,7 +273,7 @@ func TestDUintDefault(t *testing.T) {
 	def := uint(20)
 	res := DUint(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -282,7 +282,7 @@ func TestDUint8Value(t *testing.T) {
 	def := uint8(20)
 	res := DUint8(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -290,7 +290,7 @@ func TestDUint8Default(t *testing.T) {
 	def := uint8(20)
 	res := DUint8(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -299,7 +299,7 @@ func TestDUint16Value(t *testing.T) {
 	def := uint16(20)
 	res := DUint16(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -307,7 +307,7 @@ func TestDUint16Default(t *testing.T) {
 	def := uint16(20)
 	res := DUint16(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -316,7 +316,7 @@ func TestDUint32Value(t *testing.T) {
 	def := uint32(20)
 	res := DUint32(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -324,7 +324,7 @@ func TestDUint32Default(t *testing.T) {
 	def := uint32(20)
 	res := DUint32(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -333,7 +333,7 @@ func TestDUint64Value(t *testing.T) {
 	def := uint64(20)
 	res := DUint64(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -341,7 +341,7 @@ func TestDUint64Default(t *testing.T) {
 	def := uint64(20)
 	res := DUint64(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }
 
@@ -350,7 +350,7 @@ func TestDUintptrValue(t *testing.T) {
 	def := uintptr(20)
 	res := DUintptr(x, def)
 	if res != *x {
-		t.Fatalf("expected %t, got %t", *x, res)
+		t.Fatalf("expected %T, got %T", *x, res)
 	}
 }
 
@@ -358,6 +358,6 @@ func TestDUintptrDefault(t *testing.T) {
 	def := uintptr(20)
 	res := DUintptr(nil, def)
 	if res != def {
-		t.Fatalf("expected %t, got %t", def, res)
+		t.Fatalf("expected %T, got %T", def, res)
 	}
 }

--- a/string.go
+++ b/string.go
@@ -15,6 +15,10 @@ func S(v interface{}) string {
 	item := reflect.ValueOf(v)
 	if item.Kind() == reflect.Ptr {
 		item = item.Elem()
+
+		if !item.IsValid() {
+			return fmt.Sprint(nil)
+		}
 	}
 
 	return fmt.Sprint(item)

--- a/string_test.go
+++ b/string_test.go
@@ -90,7 +90,7 @@ func TestS_Nil(t *testing.T) {
 	}
 	
 	var s *string
-	if S(s) != "<nil"> {
+	if S(s) != "<nil>" {
 		t.Errorf("S(<nil string>) = \"%v\", want \"<nil>\"", S(s))
 	}
 }

--- a/string_test.go
+++ b/string_test.go
@@ -88,4 +88,9 @@ func TestS_Nil(t *testing.T) {
 	if S(nil) != "<nil>" {
 		t.Errorf("S(nil) = \"%v\", want \"<nil>\"", S(nil))
 	}
+	
+	var s *string
+	if S(s) != "<nil"> {
+		t.Errorf("S(<nil string>) = \"%v\", want \"<nil>\"", S(s))
+	}
 }


### PR DESCRIPTION
Previous implementation of this function outputted reflect jargon when a typed nil was passed.

Bonus increment of the Go version in CI.