### PR TITLE
Fix pointer string helper for interfaces

### DIFF
--- a/string.go
+++ b/string.go
@@ -13,13 +13,12 @@ func S(v interface{}) string {
 	}
 
 	item := reflect.ValueOf(v)
-	if item.Kind() == reflect.Ptr {
-		item = item.Elem()
-
-		if !item.IsValid() {
+	for item.Kind() == reflect.Ptr || item.Kind() == reflect.Interface {
+		if item.IsNil() {
 			return fmt.Sprint(nil)
 		}
+		item = item.Elem()
 	}
 
-	return fmt.Sprint(item)
+	return fmt.Sprint(item.Interface())
 }

--- a/string_test.go
+++ b/string_test.go
@@ -88,9 +88,17 @@ func TestS_Nil(t *testing.T) {
 	if S(nil) != "<nil>" {
 		t.Errorf("S(nil) = \"%v\", want \"<nil>\"", S(nil))
 	}
-	
+
 	var s *string
 	if S(s) != "<nil>" {
 		t.Errorf("S(<nil string>) = \"%v\", want \"<nil>\"", S(s))
+	}
+}
+
+func TestS_InterfacePointer(t *testing.T) {
+	name := "Dwight"
+	var val interface{} = &name
+	if res := S(&val); res != name {
+		t.Errorf("S(&interface{pointer}) = %q, want %q", res, name)
 	}
 }


### PR DESCRIPTION
## Summary
- fix S helper so that interface pointer values are dereferenced properly
- add regression test for interface pointer values

## Testing
- `GO111MODULE=off go test ./...`
